### PR TITLE
If curl fails downloading compose, make it fail and remove the file

### DIFF
--- a/manifests/compose.pp
+++ b/manifests/compose.pp
@@ -45,7 +45,7 @@ class docker::compose(
     exec { "Install Docker Compose ${version}":
       path    => '/usr/bin/',
       cwd     => '/tmp',
-      command => "curl -s -L ${proxy_opt} https://github.com/docker/compose/releases/download/${version}/docker-compose-${::kernel}-x86_64 > ${install_path}/docker-compose-${version}",
+      command => "curl -f -s -L ${proxy_opt} https://github.com/docker/compose/releases/download/${version}/docker-compose-${::kernel}-x86_64 > ${install_path}/docker-compose-${version} || rm -f ${install_path}/docker-compose-${version}",
       creates => "${install_path}/docker-compose-${version}",
       require => Package['curl'],
     }


### PR DESCRIPTION
This is necessary in order to avoid curl creating an empty compose binary, which would result in weird errors when trying to execute it.